### PR TITLE
timekeep package needed, too

### DIFF
--- a/omni.dependencies
+++ b/omni.dependencies
@@ -16,5 +16,11 @@
     "repository":   "sonyxperiadev/thermanager",
     "target_path":  "vendor/sony/system/thermanager",
     "revision":     "master"
+  },
+  {
+    "remote":       "github",
+    "repository":   "sonyxperiadev/timekeep",
+    "target_path":  "vendor/sony/system/timekeep",
+    "revision":     "master"
   }
 ]


### PR DESCRIPTION
It is used in shinano, (shinano-common), for time persistence
device.mk
Line 167:

```
PRODUCT_PACKAGES += \
    timekeep \
    TimeKeep \
```
